### PR TITLE
Fix rgb -> rgba in svg-color

### DIFF
--- a/Backends/Emacs/emacs.lisp
+++ b/Backends/Emacs/emacs.lisp
@@ -246,6 +246,6 @@
   "Return an SVG color string representing INK (which may be NIL.)"
   (if ink
       (multiple-value-bind (r g b a) (color-rgba ink)
-        (format nil "rgb(~f%, ~f%, ~f%, ~f)" (* r 100) (* g 100) (* b 100) a))
+        (format nil "rgba(~f%, ~f%, ~f%, ~f)" (* r 100) (* g 100) (* b 100) a))
       "none"))
 


### PR DESCRIPTION
RGB extended to include alpha is indicated by 'rgba' in CSS Color Module Level 3 section 4.2.2 as included in SVG specification.